### PR TITLE
improved minwordsperline and also added jokes

### DIFF
--- a/engine/patches/minwordsperline.js
+++ b/engine/patches/minwordsperline.js
@@ -15,17 +15,12 @@
 // just because it looks a little nicer, honestly. i mean, it doesn't matter,
 // not really, but these sort of little aesthetic considerations are what
 // set apart good developers from great ones
-//
-// not that i'm calling myself a great developer. you've seen how i code.
-// also, this may not be compatible with inline HTML. like, custom classes and
-// spans that are in the physical ink. i'm not sure how to neatly avoid that?
-// please feel free to pull request this
 
 var credits = {
 	emoji: "📝",
 	name: "Minimum words per line",
-	author: "Elliot Herriman",
-	version: "1.0.1",
+	author: "qt-dork and Elliot Herriman",
+	version: "1.1",
 	description: "Prevent lines from breaking in a way that only leaves one (or more) word(s) on the next line.",
 	licences: {
 		self: "2021",

--- a/engine/patches/minwordsperline.js
+++ b/engine/patches/minwordsperline.js
@@ -42,7 +42,7 @@ function noOrphans(textItems, length) {
 	// Stick a span right before the second to last word
 	textItems[textItems.length - length] = `<span style='white-space: nowrap'>` + textItems[textItems.length - 2];
 	// Stick a closing span right after the last word
-	targetWord[textItems.length - 1] = targetWord[textItems.length - 1] + `</span>`;
+	textItems[textItems.length - 1] = textItems[textItems.length - 1] + `</span>`;
 
 	return textItems;
 }

--- a/engine/patches/minwordsperline.js
+++ b/engine/patches/minwordsperline.js
@@ -40,7 +40,7 @@ var options = {
 function noOrphans(textItems, length) {
 	// Find the second to last word
 	// Stick a span right before the second to last word
-	textItems[textItems.length - 2] = `<span style='white-space: nowrap'>` + textItems[textItems.length - 2];
+	textItems[textItems.length - length] = `<span style='white-space: nowrap'>` + textItems[textItems.length - 2];
 	// Stick a closing span right after the last word
 	targetWord[textItems.length - 1] = targetWord[textItems.length - 1] + `</span>`;
 

--- a/engine/patches/minwordsperline.js
+++ b/engine/patches/minwordsperline.js
@@ -37,18 +37,6 @@ var options = {
 	minwordsperline_length: 2,
 };
 
-var currentLength;
-var rgx = getRegex(options.minwordsperline_length);
-
-function getRegex(length)
-{
-	if (length > 0)
-	{
-		currentLength = length;
-		return new RegExp("((([^ ]|<[^>]+>)+ ?){1," + length + "}$)");
-	}
-}
-
 function noOrphans(textItems, length) {
 	// Find the second to last word
 	// Stick a span right before the second to last word
@@ -85,35 +73,6 @@ function applyMinLength(story, line)
 
 	// Set the line equal to the new line
 	line.text = replacement;
-
-
-	// if there's any text that also includes a space
-	// if (line.text && line.text.trim().includes(" "))
-	// {
-	// 	// figure out how long we want to ensure the last line will be
-	// 	let length = story.options.minwordsperline_length;
-	
-	// 	// and if it's different to our previously recorded length,
-	// 	if (length != currentLength)
-	// 	{
-	// 		// we recreate our regex, and set the new currentLength
-	// 		rgx = getRegex(length);
-	// 	}
-
-	// 	// then finally we match the last X words and wrap it in a span
-	// 	// that won't break across lines
-	// 	let match = line.text.match(rgx);
-	// 	if (match && match[1])
-	// 	{
-	// 		let replacement = "<span style='white-space: nowrap'>" + match[1] + "</span>";
-	// 		if (match[1].trim().startsWith("</span>"))
-	// 		{
-	// 			match[1] = match[1].replace(/<\/span>/, "");
-	// 			replacement = "</span>" + replacement;
-	// 		}
-	// 		line.text = line.text.replace(match[1], replacement);
-	// 	}
-	// }
 }
 
 Patches.add(function()


### PR DESCRIPTION
there's three main changes:

first is the explainer. it has a joke in it now.
```js
// ensures that if a line would a widow make (character from overwatch),
// or an orphan make (a single word on the final line of a multi-line
// paragrhaph), it no longer does that.
```

second is a new function called `noOrphans(textItems, length)`, which does this:
```js
function noOrphans(textItems, length) {
	// Find the second to last word
	// Stick a span right before the second to last word
	textItems[textItems.length - length] = `<span style='white-space: nowrap'>` + textItems[textItems.length - 2];
	// Stick a closing span right after the last word
	targetWord[textItems.length - 1] = targetWord[textItems.length - 1] + `</span>`;

	return textItems;
}
```
i also like that it returns stuff rather than modifying the text directly. idk doing stuff like this while directly modifying the text sounds kinda scary.

finally is an overhaul of the main function, it's this now:
```js
function applyMinLength(story, line)
{
	// Rough function layout

	let replacement = '';

	// Split words/tags into array
	// NOTE: This trims leading/trailing whitespace, so if you're
	// using that intentionally then whoops
	let textItems = line.text.trim().replace(/&nbsp;/g, ' ').split(/ (?=[^>]*(?:<|$))/);

	// Check if the array is shorter than the length
	if (textItems.length < story.options.minwordsperline_length) {
		return;
	}

	// Maybe check if the array already has the span???????

	// Run orphan function
	textItems = noOrphans(textItems, story.options.minwordsperline_length);

	// Recombine the array
	replacement = textItems.join(' ');

	// Set the line equal to the new line
	line.text = replacement;
}
```

i hope this is the kind of improvement you're looking for! if it doesn't pass the smell test or something, lemme know and i'll either fix it or give up and cry <3