### PR TITLE
Fixed preload regexp

### DIFF
--- a/engine/patches/preload.js
+++ b/engine/patches/preload.js
@@ -103,7 +103,7 @@ Patches.add(function(content)
 		this.options.preload_tags[type].forEach((tag) =>
 		{
 			// and grab all their properties
-			for (var match of content.matchAll(new RegExp('"#":"' + tag + ':\\s*(.*?)(?="})', "gi"))) 
+			for (var match of content.matchAll(new RegExp('"#","\\^' + tag + ':\\s*(.*?)(?=","/#")', "gi")))
 			{
 				if (match["1"]) 
 				{


### PR DESCRIPTION
The `preload` patch doesn't work anymore. I guess the JSON format changed and I adapted the regexp accordingly.