### PR TITLE
Fixes for #image, #background, #linebyline

### DIFF
--- a/engine/calico.js
+++ b/engine/calico.js
@@ -1465,7 +1465,7 @@ Tags.add("image",
 			function(story, property)
 			{
 				// make sure a file name was provided
-				if (!typeof property === "string" || !property.trim()) 
+				if (typeof property !== "string" || !property.trim())
 				{
 					warn.warn("(#image) no file was provided.");
 					return;
@@ -1508,7 +1508,7 @@ Tags.add("background",
 			function(story, property)
 			{
 				// make sure a file name was provided
-				if (!typeof property === "string" || !property.trim()) 
+				if (typeof property !== "string" || !property.trim())
 				{
 					// remove remove background
 					story.outerdiv.style.backgroundImage = "";

--- a/engine/calico.js
+++ b/engine/calico.js
@@ -1639,13 +1639,12 @@ Tags.add("linebyline",
 			// if nothing was provided, then we toggle it
 			if (typeof property === "undefined")
 			{
-				story.queue.setLineByLine(!story.queue.lineByLine || true)
-			} 
-			// otherwise, we can use !! to convert it to a boolean
-			// (by inverting it twice)
+				story.queue.setLineByLine(!story.queue.lineByLine)
+			}
 			else
 			{	// otherwise, update linebyline
-				story.queue.setLineByLine(!!property);
+				// anything other than "true" is considered false
+				story.queue.setLineByLine(property.trim() === "true");
 			}
 		});
 


### PR DESCRIPTION
I've grouped these together because they are all in calico.js and they are all boolean manipulation mistakes.

#image & #background have a bad check: `!typeof property === "string"` is not equivalent to `typeof property !== "string"`. When property is undefined, it's wrong. It causes a bug when using #background without a file name to clear the background (it doesn't work).

#linebyline doesn't work well as reported in #18 
(closes #18)