### PR TITLE
Fix: Enable multiple INCLUDE statements by adding multiline regex fla…

### DIFF
--- a/engine/calico.js
+++ b/engine/calico.js
@@ -158,7 +158,7 @@ class Story
 						
 						// anyway, now we have to search our ink for any INCLUDEs
 						let includeFiles = new Set(Array.from(
-							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gi), m => m["1"]
+							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gim), m => m["1"]
 						));
 
 						// and iterate through the ones we find,

--- a/engine/calico.js
+++ b/engine/calico.js
@@ -2348,7 +2348,7 @@ function splitAtCharacter(text, character)
 	{		
 		// return it, and the value after
 		return {
-					before: text.substr(0, splitIndex).trim(),
+					before: text.substr(0, splitIndex).trim().toLowerCase(),
 					after: text.substr(splitIndex+1).trim()
 				};
 	}

--- a/templates/Calico [Template]/calico.js
+++ b/templates/Calico [Template]/calico.js
@@ -158,7 +158,7 @@ class Story
 						
 						// anyway, now we have to search our ink for any INCLUDEs
 						let includeFiles = new Set(Array.from(
-							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gi), m => m["1"]
+							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gim), m => m["1"]
 						));
 
 						// and iterate through the ones we find,

--- a/templates/Calico [Template]/calico.js
+++ b/templates/Calico [Template]/calico.js
@@ -2348,7 +2348,7 @@ function splitAtCharacter(text, character)
 	{		
 		// return it, and the value after
 		return {
-					before: text.substr(0, splitIndex).trim(),
+					before: text.substr(0, splitIndex).trim().toLowerCase(),
 					after: text.substr(splitIndex+1).trim()
 				};
 	}

--- a/templates/Winter [Sample project]/calico.js
+++ b/templates/Winter [Sample project]/calico.js
@@ -158,7 +158,7 @@ class Story
 						
 						// anyway, now we have to search our ink for any INCLUDEs
 						let includeFiles = new Set(Array.from(
-							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gi), m => m["1"]
+							storyContent.matchAll(/^\s*INCLUDE (.+\.ink)\s*/gim), m => m["1"]
 						));
 
 						// and iterate through the ones we find,

--- a/templates/Winter [Sample project]/calico.js
+++ b/templates/Winter [Sample project]/calico.js
@@ -2348,7 +2348,7 @@ function splitAtCharacter(text, character)
 	{		
 		// return it, and the value after
 		return {
-					before: text.substr(0, splitIndex).trim(),
+					before: text.substr(0, splitIndex).trim().toLowerCase(),
 					after: text.substr(splitIndex+1).trim()
 				};
 	}


### PR DESCRIPTION
…g in calico.js**What does this PR do?**
Fixes an issue where loading raw `.ink` files directly in the browser would fail to parse multiple `INCLUDE` statements.

**Why is this needed?**
In the `loadInk()` function within `calico.js`, the regular expression `/^\s*INCLUDE (.+\.ink)\s*/gi` is used to find imported `.ink` files. Because it lacks the `m` (multiline) flag, the `^` anchor only matches the absolute beginning of the entire string/file. 

As a result, only an `INCLUDE` on the very first line is detected. Any subsequent `INCLUDE` statements on following lines are missed, which causes `ink.js` to throw an `Error: Cannot locate [Filename]. Are you trying a relative import ?`.

**The Fix:**
Added the `m` flag to the RegExp (`/^\s*INCLUDE (.+\.ink)\s*/gim`) so that `^` correctly matches the start of each line. 

**Files modified:**
* `engine/calico.js`
* `templates/Calico [Template]/calico.js`
* `templates/Winter [Sample project]/calico.js`

**How to test:**
1. Create a main `.ink` file with multiple `INCLUDE` statements on separate lines.
2. Attempt to run it directly via `project.js` using `var story = new Story("main.ink");`.
3. Before this PR, it throws an error attempting to locate the second included file.
4. With this PR, all included files are fetched and compiled successfully.